### PR TITLE
Mask hotfix

### DIFF
--- a/xpdan/data_reduction.py
+++ b/xpdan/data_reduction.py
@@ -386,12 +386,12 @@ def integrate_and_save_last(dark_sub_bool=True, polarization_factor=0.99,
         polarization correction factor, ranged from -1(vertical) to 
         +1 (horizontal). default is 0.99. set to None for no
         correction.
-    mask_setting : str, optional
+    mask_setting : str, ndarray optional
         string for mask option. Valid options are 'default', 'auto' and
         'None'. If 'default', mask included in metadata will be
         used. If 'auto', a new mask would be generated from current
-        image. If 'None', no mask would be applied. predefined option is
-        'default'.
+        image. If 'None', no mask would be applied. If a ndarray of bools use
+        as mask. Predefined option is 'default'.
     mask_dict : dict, optional
         dictionary stores options for automasking functionality. 
         default is defined by an_glbl.auto_mask_dict. 

--- a/xpdan/data_reduction.py
+++ b/xpdan/data_reduction.py
@@ -199,12 +199,12 @@ def integrate_and_save(headers, dark_sub_bool=True,
         polarization correction factor, ranged from -1(vertical) to +1
         (horizontal). default is 0.99. set to None for no
         correction.
-    mask_setting : str, optional
+    mask_setting : str, ndarray optional
         string for mask option. Valid options are 'default', 'auto' and
         'None'. If 'default', mask included in metadata will be
         used. If 'auto', a new mask would be generated from current
-        image. If 'None', no mask would be applied. predefined option is
-        'default'.
+        image. If 'None', no mask would be applied. If a ndarray of bools use
+        as mask. Predefined option is 'default'.
     mask_dict : dict, optional
         dictionary stores options for automasking functionality.
         default is defined by an_glbl.auto_mask_dict.
@@ -295,7 +295,10 @@ def integrate_and_save(headers, dark_sub_bool=True,
             # masking logic
             # workflow for xpdAcq v0.5.1 release, will change later
             mask = None
-            if mask_setting == 'default':
+            if type(mask_setting) == np.ndarray and \
+                            mask_setting.dtype == np.dtype('bool'):
+                mask = mask_setting
+            elif mask_setting == 'default':
                 mask_md = header.start.get('mask', None)
                 if mask_md is None:
                     print("INFO: no mask associated or mask information was"

--- a/xpdan/data_reduction.py
+++ b/xpdan/data_reduction.py
@@ -199,7 +199,7 @@ def integrate_and_save(headers, dark_sub_bool=True,
         polarization correction factor, ranged from -1(vertical) to +1
         (horizontal). default is 0.99. set to None for no
         correction.
-    mask : str, optional
+    mask_setting : str, optional
         string for mask option. Valid options are 'default', 'auto' and
         'None'. If 'default', mask included in metadata will be
         used. If 'auto', a new mask would be generated from current
@@ -383,7 +383,7 @@ def integrate_and_save_last(dark_sub_bool=True, polarization_factor=0.99,
         polarization correction factor, ranged from -1(vertical) to 
         +1 (horizontal). default is 0.99. set to None for no
         correction.
-    mask : str, optional
+    mask_setting : str, optional
         string for mask option. Valid options are 'default', 'auto' and
         'None'. If 'default', mask included in metadata will be
         used. If 'auto', a new mask would be generated from current

--- a/xpdan/data_reduction.py
+++ b/xpdan/data_reduction.py
@@ -155,7 +155,8 @@ def _prepare_header_list(headers):
 def _load_config(header):
     try:
         with open(
-                os.path.join(an_glbl.config_base, an_glbl.calib_config_name)) as f:
+                os.path.join(an_glbl.config_base,
+                             an_glbl.calib_config_name)) as f:
             config_dict = yaml.load(f)
     except FileNotFoundError:
         config_dict = header.start.get('calibration_md', None)
@@ -261,7 +262,7 @@ def integrate_and_save(headers, dark_sub_bool=True,
         # config_dict
         if config_dict is None:
             config_dict = _load_config(header)  # default dict
-            if config_dict is None: # still None
+            if config_dict is None:  # still None
                 print("INFO: can't find calibration parameter under "
                       "xpdUser/config_base/ or header metadata\n"
                       "data reduction can not be perfomed.")
@@ -294,7 +295,7 @@ def integrate_and_save(headers, dark_sub_bool=True,
             # masking logic
             # workflow for xpdAcq v0.5.1 release, will change later
             mask = np.ones(img.shape).astype(bool)
-            if mask=='default':
+            if mask == 'default':
                 mask_md = header.start.get('mask', None)
                 if mask_md is None:
                     print("INFO: no mask associated or mask information was"
@@ -304,9 +305,9 @@ def integrate_and_save(headers, dark_sub_bool=True,
                 print("INFO: pull off mask associate with your image: {}"
                       .format(f_name))
                 mask = decompress_mask(data, ind, indtpr, img.shape)
-            elif mask=='auto':
+            elif mask == 'auto':
                 mask = mask_img(img, ai, **glbl.mask_dict)
-            elif mask=='None':
+            elif mask == 'None':
                 mask = None
             mask_fn = os.path.splitext(f_name)[0]  # remove ext
             if mask is not None:

--- a/xpdan/data_reduction.py
+++ b/xpdan/data_reduction.py
@@ -333,7 +333,7 @@ def integrate_and_save(headers, dark_sub_bool=True,
                 print("INFO: save chi file: {}".format(fn))
                 if mask_setting is not None:
                     # make a copy, don't overwrite it
-                    _mask = ~mask_setting
+                    _mask = ~mask
 
                 rv = ai.integrate1d(img, npt, filename=fn, mask=_mask,
                                     polarization_factor=polarization_factor,

--- a/xpdan/data_reduction.py
+++ b/xpdan/data_reduction.py
@@ -366,7 +366,7 @@ def integrate_and_save(headers, dark_sub_bool=True,
 
 
 def integrate_and_save_last(dark_sub_bool=True, polarization_factor=0.99,
-                            mask='default', mask_dict=None,
+                            mask_setting='default', mask_dict=None,
                             save_image=True, root_dir=None,
                             config_dict=None, handler=xpd_data_proc,
                             sum_idx_list=None,
@@ -428,7 +428,7 @@ def integrate_and_save_last(dark_sub_bool=True, polarization_factor=0.99,
     """
     integrate_and_save(handler.exp_db[-1], dark_sub_bool=dark_sub_bool,
                        polarization_factor=polarization_factor,
-                       mask_setting=mask, mask_dict=mask_dict,
+                       mask_setting=mask_setting, mask_dict=mask_dict,
                        save_image=save_image,
                        root_dir=root_dir,
                        config_dict=config_dict,

--- a/xpdan/data_reduction.py
+++ b/xpdan/data_reduction.py
@@ -331,9 +331,11 @@ def integrate_and_save(headers, dark_sub_bool=True,
                                    [chi_fn_Q, chi_fn_2th],
                                    [header_rv_list_Q, header_rv_list_2theta]):
                 print("INFO: save chi file: {}".format(fn))
-                if mask_setting is not None:
+                if mask is not None:
                     # make a copy, don't overwrite it
                     _mask = ~mask
+                else:
+                    _mask = None
 
                 rv = ai.integrate1d(img, npt, filename=fn, mask=_mask,
                                     polarization_factor=polarization_factor,

--- a/xpdan/tests/test_data_reduction.py
+++ b/xpdan/tests/test_data_reduction.py
@@ -3,6 +3,7 @@ from xpdan.data_reduction import integrate_and_save, sum_images, \
 from itertools import tee, product
 import pytest
 from pprint import pprint
+import numpy as np
 
 sum_idx_values = (
     None, 'all', [1, 2, 3], [(1, 3)], [[1, 2, 3], [2, 3]], [[1, 3], (1, 3)])
@@ -17,7 +18,9 @@ integrate_params = ['dark_sub_bool',
                     'sum_idx_list']
 good_kwargs = [(True, False), (.99,
                                # .95, .5
-                               ), ('default', 'auto','None'),
+                               ), ('default', 'auto','None',
+                                   np.random.random_integers(
+                                       0, 1, (200, 200))),
                                [None, {'alpha': 3}],
                (True, False), [None], [None], sum_idx_values]
 

--- a/xpdan/tests/test_data_reduction.py
+++ b/xpdan/tests/test_data_reduction.py
@@ -9,7 +9,7 @@ sum_idx_values = (
 
 integrate_params = ['dark_sub_bool',
                     'polarization_factor',
-                    'mask',
+                    'mask_setting',
                     'mask_dict',
                     'save_image',
                     'root_dir',


### PR DESCRIPTION
Closes #44 
We reused the name `mask` a few too many times and had some definitions in the wrong spots. This should fix this issue. However, the fact that none of this errored in the tests needs to be remedied in a (near) future PR.